### PR TITLE
Allow excluding stack traces in messages.

### DIFF
--- a/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram/LoggerConfigurationTelegramExtensions.cs
+++ b/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram/LoggerConfigurationTelegramExtensions.cs
@@ -39,6 +39,7 @@ namespace Serilog
         /// <param name="formatProvider">The format provider used for formatting the message.</param>
         /// <param name="restrictedToMinimumLevel"><see cref="LogEventLevel"/> value that specifies minimum logging
         /// level that will be allowed to be logged.</param>
+        /// <param name="includeStackTrace">Whether stack traces should be included</param>
         /// <returns>Instance of <see cref="LoggerConfiguration"/> object.</returns>
         public static LoggerConfiguration Telegram(
             this LoggerSinkConfiguration loggerSinkConfiguration,
@@ -47,9 +48,10 @@ namespace Serilog
             int? batchSizeLimit = null,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            bool? includeStackTrace = true)
         {
-            var telegramSinkOptions = new TelegramSinkOptions(botToken, chatId, batchSizeLimit, period, formatProvider);
+            var telegramSinkOptions = new TelegramSinkOptions(botToken, chatId, batchSizeLimit, period, formatProvider, includeStackTrace: includeStackTrace);
             return loggerSinkConfiguration.Telegram(telegramSinkOptions, restrictedToMinimumLevel);
         }
 

--- a/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram/Sinks/Telegram/ExtendedLogEvent.cs
+++ b/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram/Sinks/Telegram/ExtendedLogEvent.cs
@@ -32,11 +32,12 @@ namespace Serilog.Sinks.Telegram
         /// <param name="lastOccurrence">The last occurrence.</param>
         /// <param name="logEvent">The log event.</param>
         // ReSharper disable once UnusedMember.Global
-        public ExtendedLogEvent(DateTime firstOccurrence, DateTime lastOccurrence, LogEvent logEvent)
+        public ExtendedLogEvent(DateTime firstOccurrence, DateTime lastOccurrence, LogEvent logEvent, bool? includeStackTrace = true)
         {
             this.FirstOccurrence = firstOccurrence;
             this.LastOccurrence = lastOccurrence;
             this.LogEvent = logEvent;
+            this.IncludeStackTrace = includeStackTrace ?? true;
         }
 
         /// <summary>
@@ -53,5 +54,10 @@ namespace Serilog.Sinks.Telegram
         /// Gets or sets the last occurrence.
         /// </summary>
         public DateTimeOffset LastOccurrence { get; set; }
+
+        /// <summary>
+        /// Whether stack traces are included.
+        /// </summary>
+        public bool IncludeStackTrace { get; set; }
     }
 }

--- a/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram/Sinks/Telegram/TelegramSink.cs
+++ b/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram/Sinks/Telegram/TelegramSink.cs
@@ -77,7 +77,8 @@ namespace Serilog.Sinks.Telegram
                             {
                                 LogEvent = logEvent,
                                 FirstOccurrence = logEvent.Timestamp,
-                                LastOccurrence = logEvent.Timestamp
+                                LastOccurrence = logEvent.Timestamp,
+                                IncludeStackTrace = options.IncludeStackTrace
                             });
                 }
                 else
@@ -169,7 +170,10 @@ namespace Serilog.Sinks.Telegram
             sb.AppendLine($"\n*{extLogEvent.LogEvent.Exception.Message}*\n");
             sb.AppendLine($"Message: `{extLogEvent.LogEvent.Exception.Message}`");
             sb.AppendLine($"Type: `{extLogEvent.LogEvent.Exception.GetType().Name}`\n");
-            sb.AppendLine($"Stack Trace\n```{extLogEvent.LogEvent.Exception}```");
+            if (extLogEvent.IncludeStackTrace)
+            {
+                sb.AppendLine($"Stack Trace\n```{extLogEvent.LogEvent.Exception}```");
+            }
 
             return sb.ToString();
         }

--- a/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram/Sinks/Telegram/TelegramSinkOptions.cs
+++ b/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram/Sinks/Telegram/TelegramSinkOptions.cs
@@ -40,7 +40,7 @@ namespace Serilog.Sinks.Telegram
         /// <param name="formatProvider">The format provider used for formatting the message.</param>
         /// <param name="minimumLogEventLevel">The minimum log event level to use.</param>
         /// <param name="sendBatchesAsSingleMessages">A value indicating whether the batches are sent as single messages or as one block of messages.</param>
-        public TelegramSinkOptions(string botToken, string chatId, int? batchSizeLimit = null, TimeSpan? period = null, IFormatProvider formatProvider = null, LogEventLevel minimumLogEventLevel = LogEventLevel.Verbose, bool? sendBatchesAsSingleMessages = true)
+        public TelegramSinkOptions(string botToken, string chatId, int? batchSizeLimit = null, TimeSpan? period = null, IFormatProvider formatProvider = null, LogEventLevel minimumLogEventLevel = LogEventLevel.Verbose, bool? includeStackTrace = true, bool ? sendBatchesAsSingleMessages = true)
         {
             if (botToken == null)
             {
@@ -59,6 +59,7 @@ namespace Serilog.Sinks.Telegram
             this.FormatProvider = formatProvider;
             this.MinimumLogEventLevel = minimumLogEventLevel;
             this.SendBatchesAsSingleMessages = sendBatchesAsSingleMessages ?? true;
+            this.IncludeStackTrace = includeStackTrace ?? true;
         }
 
         /// <summary>
@@ -95,5 +96,10 @@ namespace Serilog.Sinks.Telegram
         /// Gets a value indicating whether the batches are sent as single messages or as one block of messages.
         /// </summary>
         public bool SendBatchesAsSingleMessages { get; }
+
+        /// <summary>
+		/// Gets whether stack traces should be sent with messages.
+		/// </summary>
+		public bool IncludeStackTrace { get; }
     }
 }


### PR DESCRIPTION
For shorter messages in Telegram, where details can be viewed from an alternate sink.