### PR TITLE
Fix bug where Telegram returns a Bad Request because of tag characters in the stack traces

### DIFF
--- a/src/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram.csproj
+++ b/src/Serilog.Sinks.Telegram/Serilog.Sinks.Telegram.csproj
@@ -19,6 +19,10 @@
     <PackageReleaseNotes>Version 1.0.12.0 (2021-06-04): Updated nuget packages.</PackageReleaseNotes>
     <PackageLicenseFile>License.txt</PackageLicenseFile>
     <LangVersion>latest</LangVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/Serilog.Sinks.Telegram/Sinks/Telegram/TelegramSink.cs
+++ b/src/Serilog.Sinks.Telegram/Sinks/Telegram/TelegramSink.cs
@@ -191,7 +191,7 @@ namespace Serilog.Sinks.Telegram
 
             if (extLogEvent.IncludeStackTrace)
             {
-                var exception = $"{extLogEvent.LogEvent.Exception}";
+                var exception = $"{extLogEvent.LogEvent.Exception}".Replace("<", "&lt;").Replace(">", "&gt;");
                 sb.AppendLine($"Stack Trace\n<code>{exception}</code>");
             }
 


### PR DESCRIPTION
1. Escape tag characters in the stack traces
2. Enable SourceLink for future debugging