### PR TITLE
add custom bot-api-url

### DIFF
--- a/HowToUse.md
+++ b/HowToUse.md
@@ -24,6 +24,7 @@ The project can be found on [nuget](https://www.nuget.org/packages/Serilog.Sinks
 |applicationName|The name of the application sending the events in case multiple apps write to the same channel.|`applicationName: "My App"`|`string.Empty`|
 |failureCallback|Adds an option to add a failure callback action.|`failureCallback: e => Console.WriteLine($"Sink error: {e.Message}")`|`null`|
 |useCustomHtmlFormatting|An option to allow custom HTML formatting inside the message text and the application name (Use only if really needed). Make sure to use the HTML formatting from https://core.telegram.org/bots/api#html-style.|`true`|`false`|
+|botApiUrl|Custom Bot API Url|https://telegram.something.com/bot|
 
 ## Configuration via JSON options
 
@@ -42,7 +43,8 @@ The project can be found on [nuget](https://www.nuget.org/packages/Serilog.Sinks
                     "chatId": "12345",
                     "restrictedToMinimumLevel": "Warning",
                     "applicationName": "My App",
-                    "dateFormat": "yyyy-MM-dd HH:mm:sszzz"
+                    "dateFormat": "yyyy-MM-dd HH:mm:sszzz",
+                    "botApiUrl": "https://telegram.something.com/bot"
                 }
             }
         ]

--- a/src/Serilog.Sinks.Telegram.Alternative/LoggerConfigurationTelegramExtensions.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/LoggerConfigurationTelegramExtensions.cs
@@ -45,6 +45,7 @@ namespace Serilog
         /// <param name="applicationName">The name of the application sending the events in case multiple apps write to the same channel.</param>
         /// <param name="failureCallback">The failure callback.</param>
         /// <param name="useCustomHtmlFormatting">A value indicating whether custom HTML formatting in the messages could be used. (Use this carefully and only if really needed).</param>
+        /// <param name="botApiUrl">The Telegram bot API URL; defaults to https://api.telegram.org/bot</param>
         /// <returns>Instance of <see cref="LoggerConfiguration"/> object.</returns>
         public static LoggerConfiguration Telegram(
             this LoggerSinkConfiguration loggerSinkConfiguration,
@@ -59,7 +60,8 @@ namespace Serilog
             string dateFormat = "dd.MM.yyyy HH:mm:sszzz",
             string applicationName = "",
             Action<Exception> failureCallback = null,
-            bool useCustomHtmlFormatting = false)
+            bool useCustomHtmlFormatting = false,
+            string botApiUrl = null)
         {
             var telegramSinkOptions = new TelegramSinkOptions(
                 botToken,
@@ -73,7 +75,8 @@ namespace Serilog
                 sendBatchesAsSingleMessages,
                 includeStackTrace,
                 failureCallback,
-                useCustomHtmlFormatting);
+                useCustomHtmlFormatting,
+                botApiUrl);
             return loggerSinkConfiguration.Telegram(telegramSinkOptions, restrictedToMinimumLevel);
         }
 

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramClient.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramClient.cs
@@ -21,9 +21,9 @@ namespace Serilog.Sinks.Telegram.Alternative
     public class TelegramClient
     {
         /// <summary>
-        /// The Telegram bot API URL.
+        /// Default Value for The Telegram bot API URL.
         /// </summary>
-        private const string TelegramBotApiUrl = "https://api.telegram.org/bot";
+        private const string DefaultTelegramBotApiUrl = "https://api.telegram.org/bot";
 
         /// <summary>
         /// The API URL.
@@ -40,15 +40,16 @@ namespace Serilog.Sinks.Telegram.Alternative
         /// </summary>
         /// <param name="botToken">The Telegram bot token.</param>
         /// <param name="timeoutSeconds">The timeout seconds.</param>
+        /// <param name="botApiUrl">The Telegram bot API url.</param>
         /// <exception cref="ArgumentException">Thrown if the bot token is null or empty.</exception>
-        public TelegramClient(string botToken, int timeoutSeconds = 10)
+        public TelegramClient(string botToken, int timeoutSeconds = 10, string botApiUrl = DefaultTelegramBotApiUrl)
         {
             if (string.IsNullOrWhiteSpace(botToken))
             {
                 throw new ArgumentException("The bot token mustn't be empty.", nameof(botToken));
             }
 
-            this.apiUrl = new Uri($"{TelegramBotApiUrl}{botToken}/sendMessage");
+            this.apiUrl = new Uri($"{botApiUrl}{botToken}/sendMessage");
             this.httpClient.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
         }
 

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSink.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSink.cs
@@ -102,7 +102,7 @@ namespace Serilog.Sinks.Telegram.Alternative
                     var message = this.options.FormatProvider != null
                                       ? extendedLogEvent.LogEvent.RenderMessage(this.options.FormatProvider)
                                       : RenderMessage(extendedLogEvent, options);
-                    await this.SendMessage(this.options.BotToken, this.options.ChatId, message);
+                    await this.SendMessage(this.options.BotApiUrl, this.options.BotToken, this.options.ChatId, message);
                 }
             }
             else
@@ -131,7 +131,7 @@ namespace Serilog.Sinks.Telegram.Alternative
                 }
 
                 var messageToSend = sb.ToString();
-                await this.SendMessage(this.options.BotToken, this.options.ChatId, messageToSend);
+                await this.SendMessage(this.options.BotApiUrl, this.options.BotToken, this.options.ChatId, messageToSend);
             }
         }
 
@@ -221,15 +221,16 @@ namespace Serilog.Sinks.Telegram.Alternative
         /// <summary>
         /// Sends the message.
         /// </summary>
+        /// <param name="botApiUrl">The bot API url</param>
         /// <param name="token">The token.</param>
         /// <param name="chatId">The chat identifier.</param>
         /// <param name="message">The message.</param>
         /// <returns>A <see cref="Task"/> representing any asynchronous operation.</returns>
-        private async Task SendMessage(string token, string chatId, string message)
+        private async Task SendMessage(string botApiUrl, string token, string chatId, string message)
         {
             this.TryWriteToSelflog($"Trying to send message to chatId '{chatId}': '{message}'.");
             
-            var client = new TelegramClient(token, 5);
+            var client = new TelegramClient(token, 5, botApiUrl);
 
             try
             {

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSinkOptions.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSinkOptions.cs
@@ -45,6 +45,7 @@ namespace Serilog.Sinks.Telegram.Alternative
         /// <param name="includeStackTrace">A value indicating whether the stack trace should be shown or not.</param>
         /// <param name="failureCallback">The failure callback.</param>
         /// <param name="useCustomHtmlFormatting">A value indicating whether custom HTML formatting in the messages could be used. (Use this carefully and only if really needed).</param>
+        /// <param name="botApiUrl">The Telegram bot API URL; defaults to https://api.telegram.org/bot</param>
         public TelegramSinkOptions(
             string botToken,
             string chatId,
@@ -57,7 +58,8 @@ namespace Serilog.Sinks.Telegram.Alternative
             bool? sendBatchesAsSingleMessages = true,
             bool? includeStackTrace = true,
             Action<Exception> failureCallback = null,
-            bool useCustomHtmlFormatting = false)
+            bool useCustomHtmlFormatting = false,
+            string botApiUrl = null)
         {
             if (botToken == null)
             {
@@ -81,7 +83,13 @@ namespace Serilog.Sinks.Telegram.Alternative
             this.DateFormat = dateFormat;
             this.ApplicationName = applicationName;
             this.UseCustomHtmlFormatting = useCustomHtmlFormatting;
+            this.BotApiUrl = botApiUrl;
         }
+
+        /// <summary>
+        /// Gets the Telegram bot API Url
+        /// </summary>
+        public string BotApiUrl { get; }
 
         /// <summary>
         /// Gets the Telegram bot token.


### PR DESCRIPTION
In some countries, governments block requests to the telegram url. This PR is necessary to bypass this issue.