### PR TITLE
Feature: Add support for output templates.

### DIFF
--- a/src/Serilog.Sinks.Telegram.Alternative/LoggerConfigurationTelegramExtensions.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/LoggerConfigurationTelegramExtensions.cs
@@ -46,6 +46,7 @@ namespace Serilog
         /// <param name="failureCallback">The failure callback.</param>
         /// <param name="useCustomHtmlFormatting">A value indicating whether custom HTML formatting in the messages could be used. (Use this carefully and only if really needed).</param>
         /// <param name="botApiUrl">The Telegram bot API url, defaults to https://api.telegram.org/bot.</param>
+        /// <param name="outputTemplate"></param>
         /// <returns>Instance of <see cref="LoggerConfiguration"/> object.</returns>
         public static LoggerConfiguration Telegram(
             this LoggerSinkConfiguration loggerSinkConfiguration,
@@ -61,7 +62,8 @@ namespace Serilog
             string applicationName = "",
             Action<Exception> failureCallback = null,
             bool useCustomHtmlFormatting = false,
-            string botApiUrl = null)
+            string botApiUrl = null,
+            string outputTemplate = null)
         {
             var telegramSinkOptions = new TelegramSinkOptions(
                 botToken,
@@ -76,7 +78,8 @@ namespace Serilog
                 includeStackTrace,
                 failureCallback,
                 useCustomHtmlFormatting,
-                botApiUrl);
+                botApiUrl,
+                outputTemplate);
             return loggerSinkConfiguration.Telegram(telegramSinkOptions, restrictedToMinimumLevel);
         }
 

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/HtmlEscaper.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/HtmlEscaper.cs
@@ -1,0 +1,20 @@
+﻿namespace Serilog.Sinks.Telegram.Alternative;
+
+/// <summary>
+///     Static class providing HTML escaping functionality.
+/// </summary>
+internal static class HtmlEscaper
+{
+    /// <summary>
+    /// Correctly escapes strings taking options into consideration.
+    /// </summary>
+    /// <param name="options">The options specified by the consumer.</param>
+    /// <param name="message">The string to escape.</param>
+    /// <returns>The properly escaped string.</returns>
+    internal static string Escape(TelegramSinkOptions options, string message)
+    {
+        return options.CustomHtmlFormatter is null
+            ? message.HtmlEscape(options.ShouldEscape)
+            : options.CustomHtmlFormatter.Invoke(message);
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/DefaultPropertyRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/DefaultPropertyRenderer.cs
@@ -4,15 +4,23 @@ using Serilog.Sinks.Telegram.Alternative;
 
 namespace Serilog.Sinks.Telegram.Output
 {
+    /// <summary>
+    ///     Fallback renderer for log event properties.
+    /// </summary>
     public class DefaultPropertyRenderer : IPropertyRenderer
     {
         private readonly PropertyToken _propertyToken;
 
+        /// <summary>
+        ///     Instantiates a new default renderer for the given property token.
+        /// </summary>
+        /// <param name="propertyToken"></param>
         public DefaultPropertyRenderer(PropertyToken propertyToken)
         {
             _propertyToken = propertyToken;
         }
 
+        /// <inheritdoc />
         public void Render(ExtendedLogEvent logEvent, TextWriter output)
         {
             if (!logEvent.LogEvent.Properties.TryGetValue(_propertyToken.PropertyName, out var propertyValue))

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/DefaultPropertyRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/DefaultPropertyRenderer.cs
@@ -1,0 +1,27 @@
+﻿using System.IO;
+using Serilog.Parsing;
+using Serilog.Sinks.Telegram.Alternative;
+
+namespace Serilog.Sinks.Telegram.Output
+{
+    public class DefaultPropertyRenderer : IPropertyRenderer
+    {
+        private readonly PropertyToken _propertyToken;
+
+        public DefaultPropertyRenderer(PropertyToken propertyToken)
+        {
+            _propertyToken = propertyToken;
+        }
+
+        public void Render(ExtendedLogEvent logEvent, TextWriter output)
+        {
+            if (!logEvent.LogEvent.Properties.TryGetValue(_propertyToken.PropertyName, out var propertyValue))
+            {
+                output.Write(_propertyToken.ToString());
+                return;
+            }
+
+            propertyValue.Render(output, _propertyToken.Format);
+        }
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/ExceptionRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/ExceptionRenderer.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+using Serilog.Parsing;
+using Serilog.Sinks.Telegram.Alternative;
+
+namespace Serilog.Sinks.Telegram.Output
+{
+    public class ExceptionRenderer : IPropertyRenderer
+    {
+        private readonly PropertyToken _propertyToken;
+        private readonly TelegramSinkOptions _options;
+
+        public ExceptionRenderer(PropertyToken propertyToken, TelegramSinkOptions options)
+        {
+            _propertyToken = propertyToken;
+            _options = options;
+        }
+
+        public void Render(ExtendedLogEvent extLogEvent, TextWriter output)
+        {
+            if (extLogEvent.LogEvent.Exception is null)
+            {
+                return;
+            }
+
+            var message = extLogEvent.LogEvent.Exception.Message.HtmlEscape(_options.ShouldEscape);
+            var exceptionType = extLogEvent.LogEvent.Exception.GetType().Name.HtmlEscape(_options.ShouldEscape);
+
+            output.WriteLine($"\n<strong>{message}</strong>\n");
+            output.WriteLine($"Message: <code>{message}</code>");
+            output.WriteLine($"Type: <code>{exceptionType}</code>\n");
+
+            if (extLogEvent.IncludeStackTrace)
+            {
+                var exception = $"{extLogEvent.LogEvent.Exception}".HtmlEscape(_options.ShouldEscape);
+                output.WriteLine($"Stack Trace\n<code>{exception}</code>");
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/ExceptionRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/ExceptionRenderer.cs
@@ -4,17 +4,26 @@ using Serilog.Sinks.Telegram.Alternative;
 
 namespace Serilog.Sinks.Telegram.Output
 {
+    /// <summary>
+    ///     Renders exceptions.
+    /// </summary>
     public class ExceptionRenderer : IPropertyRenderer
     {
         private readonly PropertyToken _propertyToken;
         private readonly TelegramSinkOptions _options;
 
+        /// <summary>
+        ///     Creates a new instance of the renderer.
+        /// </summary>
+        /// <param name="propertyToken">The property token to render.</param>
+        /// <param name="options">The sink options.</param>
         public ExceptionRenderer(PropertyToken propertyToken, TelegramSinkOptions options)
         {
             _propertyToken = propertyToken;
             _options = options;
         }
 
+        /// <inheritdoc />
         public void Render(ExtendedLogEvent extLogEvent, TextWriter output)
         {
             if (extLogEvent.LogEvent.Exception is null)
@@ -22,8 +31,8 @@ namespace Serilog.Sinks.Telegram.Output
                 return;
             }
 
-            var message = extLogEvent.LogEvent.Exception.Message.HtmlEscape(_options.ShouldEscape);
-            var exceptionType = extLogEvent.LogEvent.Exception.GetType().Name.HtmlEscape(_options.ShouldEscape);
+            var message = HtmlEscaper.Escape(_options, extLogEvent.LogEvent.Exception.Message);
+            var exceptionType = HtmlEscaper.Escape(_options, extLogEvent.LogEvent.Exception.GetType().Name);
 
             output.WriteLine($"\n<strong>{message}</strong>\n");
             output.WriteLine($"Message: <code>{message}</code>");
@@ -31,7 +40,7 @@ namespace Serilog.Sinks.Telegram.Output
 
             if (extLogEvent.IncludeStackTrace)
             {
-                var exception = $"{extLogEvent.LogEvent.Exception}".HtmlEscape(_options.ShouldEscape);
+                var exception = HtmlEscaper.Escape(_options, $"{extLogEvent.LogEvent.Exception}");
                 output.WriteLine($"Stack Trace\n<code>{exception}</code>");
             }
         }

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/IPropertyRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/IPropertyRenderer.cs
@@ -1,0 +1,18 @@
+﻿using System.IO;
+using Serilog.Sinks.Telegram.Alternative;
+
+namespace Serilog.Sinks.Telegram.Output
+{
+    /// <summary>
+    /// Contract for property renderers.
+    /// </summary>
+    public interface IPropertyRenderer
+    {
+        /// <summary>
+        /// Renders the given <paramref name="logEvent"/>. Results are written to the <paramref name="output"/>.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="output">The output.</param>
+        void Render(ExtendedLogEvent logEvent, TextWriter output);
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/LogLevelRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/LogLevelRenderer.cs
@@ -1,0 +1,67 @@
+﻿using System.IO;
+using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Sinks.Telegram.Alternative;
+
+namespace Serilog.Sinks.Telegram.Output
+{
+    /// <summary>
+    /// Formats the log level of a log event for using a property token.
+    /// </summary>
+    internal class LogLevelRenderer : IPropertyRenderer
+    {
+        private readonly PropertyToken _propertyToken;
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="propertyToken">The property token.</param>
+        internal LogLevelRenderer(PropertyToken propertyToken)
+        {
+            _propertyToken = propertyToken;
+        }
+
+        /// <summary>
+        /// Renders the given <paramref name="logEvent"/> and writes the results into <paramref name="output"/>.
+        /// </summary>
+        /// <param name="logEvent">The log event.</param>
+        /// <param name="output">The output.</param>
+        public void Render(ExtendedLogEvent logEvent, TextWriter output)
+        {
+            string stringLevel = logEvent.LogEvent.Level.ToString();
+            switch (_propertyToken.Format)
+            {
+                case "e":
+                    stringLevel = GetEmoji(logEvent.LogEvent);
+                    break;
+                case "u":
+                    stringLevel = stringLevel.ToUpperInvariant();
+                    break;
+                case "l":
+                    stringLevel = stringLevel.ToLowerInvariant();
+                    break;
+            }
+
+            output.Write(stringLevel);
+        }
+
+        /// <summary>
+        /// Gets the emoji.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <returns>The emoji as <see cref="string"/>.</returns>
+        internal static string GetEmoji(LogEvent log)
+        {
+            return log.Level switch
+            {
+                LogEventLevel.Debug => "👉",
+                LogEventLevel.Error => "❗",
+                LogEventLevel.Fatal => "‼",
+                LogEventLevel.Information => "ℹ",
+                LogEventLevel.Verbose => "⚡",
+                LogEventLevel.Warning => "⚠",
+                _ => string.Empty
+            };
+        }
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/MessageRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/MessageRenderer.cs
@@ -5,17 +5,26 @@ using Serilog.Sinks.Telegram.Alternative;
 
 namespace Serilog.Sinks.Telegram.Output
 {
+    /// <summary>
+    ///     Renders the Message property of a log event.
+    /// </summary>
     public class MessageRenderer : IPropertyRenderer
     {
         private readonly PropertyToken _propertyToken;
         private readonly TelegramSinkOptions _options;
 
+        /// <summary>
+        ///     Creates a new instance of the renderer.
+        /// </summary>
+        /// <param name="propertyToken">The property token to render.</param>
+        /// <param name="options">The sink options.</param>
         public MessageRenderer(PropertyToken propertyToken, TelegramSinkOptions options)
         {
             _propertyToken = propertyToken;
             _options = options;
         }
 
+        /// <inheritdoc />
         public void Render(ExtendedLogEvent logEvent, TextWriter output)
         {
             using var sw = new StringWriter(new StringBuilder());
@@ -31,7 +40,7 @@ namespace Serilog.Sinks.Telegram.Output
                         break;
                 }
             }
-            output.Write(sw.ToString().HtmlEscape(_options.ShouldEscape));
+            output.Write(HtmlEscaper.Escape(_options, sw.ToString()));
         }
     }
 }

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/MessageRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/MessageRenderer.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+using System.Text;
+using Serilog.Parsing;
+using Serilog.Sinks.Telegram.Alternative;
+
+namespace Serilog.Sinks.Telegram.Output
+{
+    public class MessageRenderer : IPropertyRenderer
+    {
+        private readonly PropertyToken _propertyToken;
+        private readonly TelegramSinkOptions _options;
+
+        public MessageRenderer(PropertyToken propertyToken, TelegramSinkOptions options)
+        {
+            _propertyToken = propertyToken;
+            _options = options;
+        }
+
+        public void Render(ExtendedLogEvent logEvent, TextWriter output)
+        {
+            using var sw = new StringWriter(new StringBuilder());
+            foreach (MessageTemplateToken token in logEvent.LogEvent.MessageTemplate.Tokens)
+            {
+                switch (token)
+                {
+                    case TextToken tt:
+                        TextTokenRenderer.Render(tt, output, _options);
+                        break;
+                    case PropertyToken pt:
+                        new DefaultPropertyRenderer(pt).Render(logEvent, sw);
+                        break;
+                }
+            }
+            output.Write(sw.ToString().HtmlEscape(_options.ShouldEscape));
+        }
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/OutputTemplateRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/OutputTemplateRenderer.cs
@@ -1,0 +1,68 @@
+﻿using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Serilog.Formatting.Display;
+using Serilog.Parsing;
+using Serilog.Sinks.Telegram.Alternative;
+
+namespace Serilog.Sinks.Telegram.Output
+{
+    internal class OutputTemplateRenderer
+    {
+        private const int DefaultWriteCapacity = 256;
+
+        private readonly Action<ExtendedLogEvent, TextWriter>[] _renderActions;
+
+        internal OutputTemplateRenderer(string outputTemplate, TelegramSinkOptions options)
+        {
+            MessageTemplate template = new MessageTemplateParser().Parse(outputTemplate);
+            var renderActions = new List<Action<ExtendedLogEvent, TextWriter>>();
+            foreach (MessageTemplateToken token in template.Tokens)
+            {
+                switch (token)
+                {
+                    case TextToken tt:
+                        renderActions.Add((_,w) => TextTokenRenderer.Render(tt, w, options));
+                        break;
+                    case PropertyToken pt:
+                        switch (pt.PropertyName)
+                        {
+                            case OutputProperties.LevelPropertyName:
+                                renderActions.Add(new LogLevelRenderer(pt).Render);
+                                break;
+                            case OutputProperties.NewLinePropertyName:
+                                renderActions.Add((_,w) => w.WriteLine());
+                                break;
+                            case OutputProperties.ExceptionPropertyName:
+                                renderActions.Add(new ExceptionRenderer(pt, options).Render);
+                                break;
+                            case OutputProperties.MessagePropertyName:
+                                renderActions.Add(new MessageRenderer(pt, options).Render);
+                                break;
+                            case OutputProperties.TimestampPropertyName:
+                                renderActions.Add(new TimestampRenderer(pt).Render);
+                                break;
+                            default:
+                                renderActions.Add(new DefaultPropertyRenderer(pt).Render);
+                                break;
+                        }
+                        break;
+                }
+            }
+
+            _renderActions = renderActions.ToArray();
+        }
+
+        public string Format(ExtendedLogEvent logEvent)
+        {
+            using var sw = new StringWriter(new StringBuilder(DefaultWriteCapacity));
+            foreach (Action<ExtendedLogEvent, TextWriter> renderAction in _renderActions)
+            {
+                renderAction(logEvent, sw);
+            }
+            return sw.ToString();
+        }
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/TextTokenRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/TextTokenRenderer.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+using Serilog.Parsing;
+using Serilog.Sinks.Telegram.Alternative;
+
+namespace Serilog.Sinks.Telegram.Output
+{
+    public class TextTokenRenderer
+    {
+        public static void Render(TextToken token, TextWriter output, TelegramSinkOptions options)
+        {
+            output.Write(token.Text.HtmlEscape(options.ShouldEscape));
+        }
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/TextTokenRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/TextTokenRenderer.cs
@@ -4,11 +4,20 @@ using Serilog.Sinks.Telegram.Alternative;
 
 namespace Serilog.Sinks.Telegram.Output
 {
+    /// <summary>
+    ///     Renders text tokens.
+    /// </summary>
     public class TextTokenRenderer
     {
+        /// <summary>
+        /// Renders the given text <paramref name="token"/>. Results are written to the <paramref name="output"/>.
+        /// </summary>
+        /// <param name="token">The text token.</param>
+        /// <param name="output">The output.</param>
+        /// <param name="options">The sink options.</param>
         public static void Render(TextToken token, TextWriter output, TelegramSinkOptions options)
         {
-            output.Write(token.Text.HtmlEscape(options.ShouldEscape));
+            output.Write(HtmlEscaper.Escape(options, token.Text));
         }
     }
 }

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/TimestampRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/TimestampRenderer.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Sinks.Telegram.Alternative;
+
+namespace Serilog.Sinks.Telegram.Output
+{
+    public class TimestampRenderer : IPropertyRenderer
+    {
+        private readonly PropertyToken _propertyToken;
+
+        public TimestampRenderer(PropertyToken propertyToken)
+        {
+            _propertyToken = propertyToken;
+        }
+
+        public void Render(ExtendedLogEvent logEvent, TextWriter output)
+        {
+            var sv = new ScalarValue(logEvent.LogEvent.Timestamp);
+            sv.Render(output, _propertyToken.Format);
+        }
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/TimestampRenderer.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/Output/TimestampRenderer.cs
@@ -5,15 +5,23 @@ using Serilog.Sinks.Telegram.Alternative;
 
 namespace Serilog.Sinks.Telegram.Output
 {
+    /// <summary>
+    ///     Renders a timestamp property of a log event.
+    /// </summary>
     public class TimestampRenderer : IPropertyRenderer
     {
         private readonly PropertyToken _propertyToken;
 
+        /// <summary>
+        ///     Creates a new instance of the renderer.
+        /// </summary>
+        /// <param name="propertyToken">The property token to render.</param>
         public TimestampRenderer(PropertyToken propertyToken)
         {
             _propertyToken = propertyToken;
         }
 
+        /// <inheritdoc />
         public void Render(ExtendedLogEvent logEvent, TextWriter output)
         {
             var sv = new ScalarValue(logEvent.LogEvent.Timestamp);

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramPropertyNames.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramPropertyNames.cs
@@ -1,0 +1,7 @@
+﻿namespace Serilog.Sinks.Telegram.Alternative
+{
+    internal static class TelegramPropertyNames
+    {
+        internal const string ApplicationName = nameof(ApplicationName);
+    }
+}

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSink.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSink.cs
@@ -171,7 +171,7 @@ namespace Serilog.Sinks.Telegram.Alternative
         {
             var sb = new StringBuilder();
             var emoji = LogLevelRenderer.GetEmoji(extLogEvent.LogEvent);
-            var renderedMessage = Escape(options, extLogEvent.LogEvent.RenderMessage());
+            var renderedMessage = HtmlEscaper.Escape(options, extLogEvent.LogEvent.RenderMessage());
 
             sb.AppendLine($"{emoji} {renderedMessage}");
             sb.AppendLine(string.Empty);
@@ -181,7 +181,7 @@ namespace Serilog.Sinks.Telegram.Alternative
             {
                 string applicationNamePart = string.IsNullOrWhiteSpace(options.ApplicationName)
                     ? string.Empty
-                    : $"{Escape(options, options.ApplicationName)}: ";
+                    : $"{HtmlEscaper.Escape(options, options.ApplicationName)}: ";
 
                 string datePart = string.IsNullOrWhiteSpace(options.DateFormat)
                     ? string.Empty
@@ -197,8 +197,8 @@ namespace Serilog.Sinks.Telegram.Alternative
                 return sb.ToString();
             }
 
-            var message = Escape(options, extLogEvent.LogEvent.Exception.Message);
-            var exceptionType = Escape(options, extLogEvent.LogEvent.Exception.GetType().Name);
+            var message = HtmlEscaper.Escape(options, extLogEvent.LogEvent.Exception.Message);
+            var exceptionType = HtmlEscaper.Escape(options, extLogEvent.LogEvent.Exception.GetType().Name);
 
             sb.AppendLine($"\n<strong>{message}</strong>\n");
             sb.AppendLine($"Message: <code>{message}</code>");
@@ -206,26 +206,11 @@ namespace Serilog.Sinks.Telegram.Alternative
 
             if (extLogEvent.IncludeStackTrace)
             {
-                var exception = Escape(options, $"{extLogEvent.LogEvent.Exception}");
+                var exception = HtmlEscaper.Escape(options, $"{extLogEvent.LogEvent.Exception}");
                 sb.AppendLine($"Stack Trace\n<code>{exception}</code>");
             }
 
             return sb.ToString();
-        }
-
-        /// <summary>
-        /// Correctly escapes strings taking options into consideration.
-        /// </summary>
-        /// <param name="options">The options specified by the consumer.</param>
-        /// <param name="message">The string to escape.</param>
-        /// <returns>The properly escaped string.</returns>
-        private static string Escape(TelegramSinkOptions options, string message)
-        {
-            var shouldEscape = !options.UseCustomHtmlFormatting;
-
-            return options.CustomHtmlFormatter is null
-                ? message.HtmlEscape(shouldEscape)
-                : options.CustomHtmlFormatter.Invoke(message);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSinkOptions.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSinkOptions.cs
@@ -46,6 +46,7 @@ namespace Serilog.Sinks.Telegram.Alternative
         /// <param name="failureCallback">The failure callback.</param>
         /// <param name="useCustomHtmlFormatting">A value indicating whether custom HTML formatting in the messages could be used. (Use this carefully and only if really needed).</param>
         /// <param name="botApiUrl">The Telegram bot API url, defaults to https://api.telegram.org/bot.</param>
+        /// <param name="outputTemplate">The template to use for output strings. Optional.</param>
         /// <param name="customHtmlFormatter">
         ///    You can pass a func in addition to <see cref="UseCustomHtmlFormatting"/> to set your custom function for escaping HTML strings.
         ///    This will only be considered if <see cref="UseCustomHtmlFormatting"/> is set to true.

--- a/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSinkOptions.cs
+++ b/src/Serilog.Sinks.Telegram.Alternative/Sinks/Telegram/TelegramSinkOptions.cs
@@ -59,7 +59,8 @@ namespace Serilog.Sinks.Telegram.Alternative
             bool? includeStackTrace = true,
             Action<Exception> failureCallback = null,
             bool useCustomHtmlFormatting = false,
-            string botApiUrl = null)
+            string botApiUrl = null,
+            string outputTemplate = null)
         {
             if (string.IsNullOrWhiteSpace(botToken))
             {
@@ -79,6 +80,7 @@ namespace Serilog.Sinks.Telegram.Alternative
             this.ApplicationName = applicationName;
             this.UseCustomHtmlFormatting = useCustomHtmlFormatting;
             this.BotApiUrl = botApiUrl;
+            this.OutputTemplate = outputTemplate;
         }
 
         /// <summary>
@@ -145,5 +147,15 @@ namespace Serilog.Sinks.Telegram.Alternative
         /// Gets a value indicating whether custom HTML formatting in the messages could be used. (Use this carefully and only if really needed).
         /// </summary>
         public bool UseCustomHtmlFormatting { get; }
+
+        /// <summary>
+        /// Gets a value whether or not string literals should be escaped.
+        /// </summary>
+        public bool ShouldEscape => !UseCustomHtmlFormatting;
+
+        /// <summary>
+        /// Get the output template.
+        /// </summary>
+        public string OutputTemplate { get; set; }
     }
 }


### PR DESCRIPTION
Implemented support for output templates. The features works very much like the one from Serilog.Sinks.Console and is strongly inspired by their work.

When no output template is given, the old behaviour is preserved.

An example output template would be:
```
{Level:e} [{ApplicationName}] {Message:lj}{NewLine}{Exception}
```

This then, for example, renders as
```
⚠️ [MyApp] Some strange event occurred.
```